### PR TITLE
Added CGVectorAngleSK, which returns an angle that matches the zRotation property on Spritekit nodes

### DIFF
--- a/CGVectorAdditions.h
+++ b/CGVectorAdditions.h
@@ -49,6 +49,9 @@ CG_INLINE CGFloat CGVectorAngleBetween(CGVector vector1, CGVector vector2);
 /* Calculate the angle of `vector` */
 CG_INLINE CGFloat CGVectorAngle(CGVector vector);
 
+/* Calculate the angle of `vector` for use with a SpriteKit zRotation property */
+CG_INLINE CGFloat CGVectorAngleSK(CGVector vector);
+
 /* Calculate the dot product of two vectors */
 CG_INLINE CGFloat CGVectorDotProduct(CGVector vector1, CGVector vector2);
 
@@ -161,6 +164,12 @@ CG_INLINE CGFloat
 CGVectorAngle(CGVector vector)
 {
     return atan2(vector.dy, vector.dx);
+}
+
+CG_INLINE CGFloat
+CGVectorAngleSK(CGVector vector)
+{
+    return fmod(M_PI * 2.0 - atan2(vector.dy, vector.dx) + M_PI_2, M_PI * 2.0);
 }
 
 CG_INLINE CGFloat

--- a/CGVectorAdditions.h
+++ b/CGVectorAdditions.h
@@ -169,7 +169,7 @@ CGVectorAngle(CGVector vector)
 CG_INLINE CGFloat
 CGVectorAngleSK(CGVector vector)
 {
-    return fmod(M_PI * 2.0 - atan2(vector.dy, vector.dx) + M_PI_2, M_PI * 2.0);
+    return fmod(M_2_PI - atan2(vector.dy, vector.dx) + M_PI_2, M_PI * 2.0);
 }
 
 CG_INLINE CGFloat

--- a/README.md
+++ b/README.md
@@ -29,6 +29,9 @@ CG_INLINE CGFloat CGVectorAngleBetween(CGVector vector1, CGVector vector2);
 /* Calculate the angle of `vector` */
 CG_INLINE CGFloat CGVectorAngle(CGVector vector);
 
+/* Calculate the angle of `vector` for use with a SpriteKit zRotation property */
+CG_INLINE CGFloat CGVectorAngleSK(CGVector vector);
+
 /* Calculate the dot product of two vectors */
 CG_INLINE CGFloat CGVectorDotProduct(CGVector vector1, CGVector vector2);
 


### PR DESCRIPTION
This is quite an interesting one. I've found that the `zRotation` property on Spritekit nodes does not match with the return value of `CGVectorAngle`. I'm not entirely sure if my approach is the absolute right one (I'm not a mathamagician, unfortunately), but the return value of `CGVectorAngleSK` seems to be correct for me.

Originally I had changed the `CGVectorAngle` function itself but changing the function directly might break existing code that uses it, so I made a new function to work around that.

It also doesn't use any optimization, which I suppose is certainly doable here. Thoughts?
